### PR TITLE
Change type of port for setSerialPort to Stream

### DIFF
--- a/src/VescUart.cpp
+++ b/src/VescUart.cpp
@@ -1,5 +1,5 @@
 #include "VescUart.h"
-#include <HardwareSerial.h>
+#include <Stream.h>
 
 VescUart::VescUart(void){
 	nunchuck.valueX         = 127;
@@ -8,7 +8,7 @@ VescUart::VescUart(void){
 	nunchuck.upperButton  	= false;
 }
 
-void VescUart::setSerialPort(HardwareSerial* port)
+void VescUart::setSerialPort(Stream* port)
 {
 	serialPort = port;
 }

--- a/src/VescUart.h
+++ b/src/VescUart.h
@@ -46,7 +46,7 @@ class VescUart
 		 * @brief      Set the serial port for uart communication
 		 * @param      port  - Reference to Serial port (pointer) 
 		 */
-		void setSerialPort(HardwareSerial* port);
+		void setSerialPort(Stream* port);
 
 		/**
 		 * @brief      Set the serial port for debugging
@@ -98,7 +98,7 @@ class VescUart
 	private: 
 
 		/** Variabel to hold the reference to the Serial object to use for UART */
-		HardwareSerial* serialPort = NULL;
+		Stream* serialPort = NULL;
 
 		/** Variabel to hold the reference to the Serial object to use for debugging. 
 		  * Uses the class Stream instead of HarwareSerial */


### PR DESCRIPTION
This allows devs to use any kind of Stream, for example SoftwareSerial,
to connect to the VESC. Since that works just fine, it's not necessary
to limit it to just HardwareSerial.
Note: I don't know if there are any scenarios where someone would want
to use anything except for a Serial port, but maybe there is some weird
case where it'd make sense to bridge the communication between Arduino
and VESC via some other communication protocol, so I went with Stream
instead of Serial.

(This is my first time doing a pull request, so please tell me about anything I'm doing wrong. Thanks!)