### PR TITLE
Fix compilation on ESP8266

### DIFF
--- a/src/VescUart.cpp
+++ b/src/VescUart.cpp
@@ -188,7 +188,7 @@ bool VescUart::processReadPacket(uint8_t * message) {
 
 	switch (packetId){
 		case COMM_GET_VALUES: // Structure defined here: https://github.com/vedderb/bldc/blob/43c3bbaf91f5052a35b75c2ff17b5fe99fad94d1/commands.c#L164
-
+		{
 			data.tempMosfet 		= buffer_get_float16(message, 10.0, &ind); 	// 2 bytes - mc_interface_temp_fet_filtered()
 			data.tempMotor 			= buffer_get_float16(message, 10.0, &ind); 	// 2 bytes - mc_interface_temp_motor_filtered()
 			data.avgMotorCurrent 	= buffer_get_float32(message, 100.0, &ind); // 4 bytes - mc_interface_read_reset_avg_motor_current()
@@ -211,10 +211,12 @@ bool VescUart::processReadPacket(uint8_t * message) {
 			return true;
 
 		break;
+		}
 
 		case COMM_GET_VALUES_SELECTIVE:
-
+		{
 			uint32_t mask = 0xFFFFFFFF;
+		}
 
 		default:
 			return false;


### PR DESCRIPTION
The VescUart library fails to compile using the ESP8266 Arduino core: `jump to case label [-fpermissive]`
Adding the necessary brackets fixes the compilation for the ESP8266