### PR TITLE
Fix buffer_get_bool does not increase the index

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -183,12 +183,12 @@ bool buffer_get_bool(const uint8_t *buffer, int32_t *index) {
 	
 		if (buffer[*index] == 1)
 		{
-			index++;
+			(*index)++;
 			return true;
 		}
 		else
 		{
-			index++;
+			(*index)++;
 			return false;
 		}
 		


### PR DESCRIPTION
I found that when getting boolean value from byte package the index is not increased. So, I checked the `buffer_get_bool` function, its increase on the value not the reference of index.  