### PR TITLE
Added additional support for ESP32/ESP8266/Teensy4.0 boards

### DIFF
--- a/src/VescUart.cpp
+++ b/src/VescUart.cpp
@@ -8,12 +8,12 @@ VescUart::VescUart(uint32_t timeout_ms) : _TIMEOUT(timeout_ms) {
 	nunchuck.upperButton  	= false;
 }
 
-void VescUart::setSerialPort(Stream* port)
+void VescUart::setSerialPort( SERIAL_PORT_TYPE* port)
 {
 	serialPort = port;
 }
 
-void VescUart::setDebugPort(Stream* port)
+void VescUart::setDebugPort( SERIAL_PORT_TYPE* port)
 {
 	debugPort = port;
 }

--- a/src/VescUart.h
+++ b/src/VescUart.h
@@ -6,6 +6,22 @@
 #include "buffer.h"
 #include "crc.h"
 
+// When using Arduino boards 
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560) 
+  #include <SoftwareSerial.h>
+  #define SERIAL_PORT_TYPE SoftwareSerial 
+// When using ESP32 or ESP8266 boards 
+#elif defined(ESP32) || defined(ESP8266)
+  #define SERIAL_PORT_TYPE HardwareSerial
+// When using Teensy 4.0 board 
+#elif defined( __IMXRT1062__ ) 
+  #define SERIAL_PORT_TYPE HardwareSerialIMXRT 
+// Other boards can be defined below
+#else 
+  #define SERIAL_PORT_TYPE HardwareSerial 
+#endif
+ 
+ 
 class VescUart
 {
 


### PR DESCRIPTION
Was added the following lines in the VescUart.h file to keep the firmwares compatible with ESP32/ESP8266 and Teensy4.0:

```
// When using Arduino boards 
#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560) 
  #include <SoftwareSerial.h>
  #define SERIAL_PORT_TYPE SoftwareSerial 
// When using ESP32 or ESP8266 boards 
#elif defined(ESP32) || defined(ESP8266)
  #define SERIAL_PORT_TYPE HardwareSerial
// When using Teensy 4.0 board 
#elif defined( __IMXRT1062__ ) 
  #define SERIAL_PORT_TYPE HardwareSerialIMXRT 
// Other boards can be defined below
#else 
  #define SERIAL_PORT_TYPE HardwareSerial 
#endif
```
 
In the VescUart.cpp I just change the lines `void VescUart::setSerialPort( Stream* port)` to `void VescUart::setSerialPort( SERIAL_PORT_TYPE* port)` where the `SERIAL_PORT_TYPE` is chosen by the .h file. The `VescUart::setDebugPort` was modified as the same.

The librarie works well. The code was tested with ESP32 and Teensy4.0 with the Mini FSESC6.7 Pro.
 
 I hope the changes bring new ideias 🤩  